### PR TITLE
Cleaned up comments; fixed access to global variables from functions

### DIFF
--- a/ATR2.py
+++ b/ATR2.py
@@ -1,10 +1,19 @@
-import random#for random.seed()
-import time#for random
-import os#for checking files
+# comments contained within {} are comments from the original code
+# but not all comments from original code are included
 
-###globals: line 69- (skipping simulator/graphics variables)
+# special Python expressions that are variables in the original code are
+# changed by adding an underscore in the front (ex: _yield, _quit)
 
-#Constant - Python has no equivalent of const
+# In python, global variables may be accessed from within a function,
+# but to change those variables, the global keyword must be used
+
+import random # for random
+import time # for random
+import os # for checking files
+
+# globals: lines 69-128 (commenting out some simulator/graphics variables)
+
+# Constant - Python has no equivalent of const
 progname = 'AT-Robots'
 version = '2.11'
 cnotice1 = 'Copyright 1997 ''99, Ed T. Toton III'
@@ -18,21 +27,21 @@ compile_ext = '.CMP'
 report_ext = '.REP'
 _T = True
 _F = False
-minint = -32768 #{maxint=32787 is alrady defined by turbo pascal}
+minint = -32768 # {maxint=32787 is alrady defined by turbo pascal}
 
-#{debugging/compiler}
+# {debugging/compiler}
 show_code = _F
 compile_by_line = _F
 max_var_len = 16
 debugging_compiler = _F
 
-#{robots}
-max_robots = 31  #{starts at 0, so total is max_robots+1}
-max_code = 1023  #{same here}
-max_op = 3  #{etc...}
+# {robots}
+max_robots = 31 # {starts at 0, so total is max_robots+1}
+max_code = 1023 # {same here}
+max_op = 3 # {etc...}
 stack_size = 256
 stack_base = 768
-max_ram = 1023  #{but this does start at 0 (odd #, 2^n-1)}
+max_ram = 1023 # {but this does start at 0 (odd #, 2^n-1)}
 max_vars = 256
 max_labels = 256
 acceleration = 4
@@ -50,7 +59,7 @@ max_config_points = 12
 max_mines = 63
 mine_blast = 35
 
-#simulator and graphics
+# simulator and graphics
 screen_scale = 0.46
 screen_x = 5
 screen_y = 5
@@ -63,7 +72,7 @@ default_slice = 5
 max_robot_lines = 8
 #Gray50 : FillPatternType = ($AA, $55, $AA, $55, $AA, $55, $AA, $55);
 
-#general settings
+# general settings
 _quit = False
 report = False
 show_cnotice = False
@@ -71,13 +80,14 @@ kill_count = 0
 report_type = 0 
 
 
-class op_rec: #line 132-134
+# Classes - "records" in original code
+class op_rec: # line 132-134
     op = [0 for i in range(0, max_op + 1)]
     
-prog_type = [op_rec() for i in range(0, max_code + 1)] #line 135
-#note: must be careful when accessing values of prog_type if we need attribute of class
+prog_type = [op_rec() for i in range(0, max_code + 1)] # line 135
+# note: must be careful when accessing values of prog_type if we need attribute of class
 
-class config_rec: #line 136-138
+class config_rec: # line 136-138
     scanner = 0 
     weapon = 0
     armor = 0
@@ -86,14 +96,14 @@ class config_rec: #line 136-138
     shield = 0
     mines = 0
 
-class mine_rec: #line 139-143
+class mine_rec: # line 139-143
     x = 0
     y = 0
     detect = 0
-    _yield = 0 #yield is a special expression, subbing _yield
+    _yield = 0 # yield is a special expression, substituting _yield
     detonate = False
 
-class robot_rec: #line 144-166 - originally a "record"
+class robot_rec: # line 144-166
     is_locked = False
     mem_watch = 0
     x = 0
@@ -167,9 +177,9 @@ class robot_rec: #line 144-166 - originally a "record"
     code = prog_type
     ram = [0 for i in range(0, max_ram + 1)]
     mine = [mine_rec() for i in range(0, max_mines + 1)]
-    errorlog = open('errorlog', 'a').close() 
+    errorlog = open('errorlog', 'a').close() # each robot has an errorlog file
 
-class missile_rec: #line 169-172 - originally a "record"
+class missile_rec: # line 169-172
     x = 0
     y = 0
     lx = 0
@@ -183,27 +193,79 @@ class missile_rec: #line 169-172 - originally a "record"
     lrad = 0
     max_rad = 0
 
-missile = []#line 179 - array or missiles, max_missiles = 1023
+# {--robot variables--}
+# lines 176-179
+num_robots = 0
+robot = [] # line 178 - array of robot_rec
+robot = [robot_rec() for i in range(-2, max_robots + 3)]
+missile = [] # line 179 - array of missile_rec
 missile = [missile_rec() for i in range(0, max_missiles + 1)]
 
-robot = []
-robot = [robot_rec() for i in range(-2, max_robots + 3)]
+# {--compiler variables--}
+# lines 181-189
+f = open('f', 'a').close()
+numvars = 0
+numlabels = 0
+maxcode = 0
+lock_pos = 0
+lock_dat = 0
+varname = ['' for i in range(0, max_vars)]
+varloc = [0 for i in range(0, max_vars)]
+labelname = ['' for i in range(0, max_vars)]
+labelnum = [0 for i in range(0, max_labels)]
+show_source = False
+compile_only = False
+lock_code = ''
+
+# {--simulator/graphics variables--}
+# lines 191-204
+bout_over = False
+step_mode = 0
+temp_mode = 0
+step_count = 0
+step_loop = False
+old_shields = False
+insane_missiles = False
+debug_info = False
+windoze = False
+no_gfx = False
+logging_errors = False
+timing = False
+show_arcs = False
+game_delay = 0
+time_slice = 0
+insanity = 0
+update_timer = 0
+max_gx = 0
+max_gy = 0
+stats_mode = 0
+game_limit = 0
+game_cycle = 0
+matches = 0
+played = 0
+executed = 0
+
+# {--general settings--}
+# lines 206-208
+_quit = False
+report = False
+show_cnotice = False
+kill_count = 0
+report_type = 0
 
 
-def max_shown():#line 347
+def max_shown(): # line 347
     if stats_mode == 1:
         return 12
-    elif stat_mode == 2:
+    elif stats_mode == 2:
         return 32
     else:
         return 6
     
 
-    
-
-def prog_error(n, ss): #line 569 in original code
-    #graph_mode(False)#graphics related
-    #textcolor(15)#graphics related
+def prog_error(n, ss): # line 569 in original code
+    #graph_mode(False) # graphics related
+    #textcolor(15) # graphics related
     print("Error #", n, ": ", end = '')
     if n == 0:
         s = ss
@@ -264,60 +326,82 @@ def prog_error(n, ss): #line 569 in original code
     exit()
     
     
-def shutdown(): #line 1325-1351
-    #graph_mode(False) #graphics
+def shutdown(): # lines 1325-1351
+    #graph_mode(False) # graphics
     if show_cnotice:
-        #textcolor(3) #graphics
-        print(progname, ' ', version, ' ')
+        #textcolor(3) # graphics
+        print(progname, '', version, '')
         print(cnotice1)
         print(cnotice2)
         print(cnotice3)
-    #textcolor(7) #graphics
-    if not registered:
-        #textcolor(4) #graphics
+    #textcolor(7) # graphics
+    if not registered: # registered defined in init - how to access here?
+        #textcolor(4) # graphics
         print('Unregistered version')
     else:
-        print('Registered to: ', reg_name)
-    #textolor(7) #graphics
+        print('Registered to: ', reg_name) # reg_name defined in init - how to access here?
+    #textolor(7) # graphics
     print()
     if logging_errors:
         for i in range(0, num_robots + 1):
             print('Robot error-log created: ' + robot[i].fn + '.ERR')
-            robot[i].errorlog = open(errorlog, 'a').close() # I think....???
+            robot[i].errorlog = open(robot[i].errorlog, 'a').close() # needs to be checked 
     quit()
 
-def delete_compile_report(): #originally line 1353
+
+def delete_compile_report(): # originally lines 1353-1357
     if os.path.isfile(main_filename + compile_ext):
         os.remove(main_filename + compile_ext)
-        #is exist part of library, also delete_file, maybe filelib
+      
         
-def write_compile_report(): #lines 1359-1376
-    f = open(main_filename + compile_ext, 'w') #assign(f, main_filename + compile_ext)
-    #rewrite(f) #don't need because open does it
-    f.write(str(num_robots + 1))#writeln(f, num_robots + 1)
+def write_compile_report(): # lines 1359-1376
+    f = open(main_filename + compile_ext, 'w') # local variable
+    f.write(str(num_robots + 1)) 
     for i in range(0, num_robots + 1):
         f.write(str(robot[i].fn))
     f.close()
-    #textcolor(15) #graphics
+    #textcolor(15) # graphics
     print()
     print("All compiles successful!")
     print()
     shutdown()
         
-def parse_param(s):#originally line 1379
-    found = False
-    s = btrim(ucase(s))#btrim, ucase in ATR2FUNC
+    
+def parse_param(s): # originally line 1379
+    global step_mode
+    global game_delay
+    global time_slice
+    global game_limit
+    global matches
+    global show_source
+    global no_gfx
+    global report
+    global report_type
+    global compile_only
+    global show_cnotice
+    global show_arcs
+    global windoze
+    global debug_info
+    global maxcode
+    global insane_missiles
+    global old_shields
+    global logging_errors
+    global insanity
+    global num_robots
+    s1 = '' # local variable
+    found = False # local variable
+    s = btrim(ucase(s)) # ATR2FUNC functions
     if s == '':
         return
     if s[0] == '#':
-        fn = rstr(s, len(s) - 1)#rstr is in atr2func
-        if fn == base_name(fn):
+        fn = rstr(s, len(s) - 1) # ATR2FUNC for rstr, fn is local
+        if fn == base_name(fn): # where is base_name defined?
             fn = fn + config_ext
         if not os.path.isfile(fn):
             prog_error(6, fn)
-        f = open(fn, 'r')
+        f = open(fn, 'r') # local variable f
         for line in f:
-            s1 = ucase(btrim(s1))
+            s1 = ucase(btrim(s1)) # ATR2FUNC
             if s1[0] == '#':
                 prog_error(7, s1)
             else:
@@ -325,14 +409,14 @@ def parse_param(s):#originally line 1379
         f.close()
         found = True
     elif s[0] in ['/', '-', '=']:
-        s1 = rstr(s, len(s) - 1)
+        s1 = rstr(s, len(s) - 1) # ATR2FUNC
         if s1[0] == 'X':
-            step_mode = value(rstr(s1, len(s1) - 1))
+            step_mode = value(rstr(s1, len(s1) - 1)) # ATR2FUNC
             found = True
             if step_mode == 0:
                 step_mode = 1
             if (step_mode < 1) or (step_mode > 9):
-                prog_error(24, rstr(s1, len(s1) - 1))
+                prog_error(24, rstr(s1, len(s1) - 1)) # ATR2FUNC
         if s1[0] == 'D':
             game_delay = value(rstr(s1, len(s1) - 1)) 
             found = True
@@ -343,7 +427,7 @@ def parse_param(s):#originally line 1379
             game_limit = value(rstr(s1, len(s1) - 1)) * 1000
             found = True
         if s1[0] == 'Q':
-            sound_on = False
+            sound_on = False # sound_on defined in init() - how to access?
             found = True
         if s1[0] == 'M': 
             matches = value(rstr(s1, len(s1) - 1))
@@ -396,7 +480,7 @@ def parse_param(s):#originally line 1379
         found = True
     elif(num_robots < max_robots) and (s != ''):
         num_robots += 1
-        create_robot(num_robots, s)
+        create_robot(num_robots, s) # need to port create_robot on line 1297
         found = True
         if num_robots == max_robots:
             print("Maximum number of robots reached.")
@@ -404,47 +488,74 @@ def parse_param(s):#originally line 1379
         prog_error(10, '')
     if not found:
         prog_error(8, s)
-    #end function
+    #end parse_params()
                  
         
  
 def init():#originally line 1452
+    global step_mode
+    global logging_errors
+    global stats_mode
+    global insane_missiles
+    global insanity
+    global windoze
+    global no_gfx
+    global timing
+    global matches
+    global played
+    global old_shields
+    global _quit
+    global compile_only
+    global show_arcs
+    global debug_info
+    global show_cnotice
+    global show_source
+    global report
+    global kill_count
+    global maxcode
+    global max_code
+    global num_robots
+    global game_limit
+    global game_cycle
+    global game_delay
+    global default_delay
+    global time_slice
+    global default_slice
+    global temp_mode
     if debugging_compiler or compile_by_line or show_code:
         print("!!! Warning !!! Compiler Debugging enabled !!!")
-        #flushkey - clears buffer so couple key presses don't race u through prog
-        #readkey - reads key
-        print()#writeln - inserts carriage return
-    step_mode = 0#{stepping disabled}
+        print() 
+    step_mode = 0 # {stepping disabled}
     logging_errors = False
     stats_mode = 0
     insane_missiles = False
     insanity = 0
-    delay_per_sec = 0
+    delay_per_sec = 0 # not a global but not a local?
     windoze = True
-    graphix = False
+    graphix = False # not a global but not a local?
     no_gfx = True
-    sound_on = True
+    sound_on = True # not a global but not a local?
     timing = True
     matches = 1
     played = 0
     old_shields = False
-    quit = False
+    _quit = False
     compile_only = False
     show_arcs = False
     debug_info = False
     show_cnotice = True
     show_source = True
-    report = False 
+    report = False
     kill_count = 0
     maxcode = max_code 
-    make_tables()#from ATR2FUNC
-    random.seed(time.time())#randomize in original
+    make_tables() # in ATR2FUNC
+    random.seed(time.time()) # "randomize" in original code
     num_robots = -1
     game_limit = 100000
     game_cycle = 0 
     game_delay = default_delay
     time_slice = default_slice
-    for i in range(0, max_missiles + 1):#line 1481-1483 of original
+    for i in range(0, max_missiles + 1):  #line 1481-1483
         missile[i].a = 0 
         missile[i].source = -1
         missile[i].x = 0
@@ -452,45 +563,44 @@ def init():#originally line 1452
         missile[i].lx = 0
         missile[i].ly = 0
         missile[i].mult = 1
-        #since missile is an array of records and Python doesn't have records, missile class
-    registered = False
-    reg_name = "Unregistered"
-    reg_num = 0xFFFF
-    check_registration()#in ATR2FUNC
+    registered = False # not a global but not a local?
+    reg_name = "Unregistered" # not a global but not a local?
+    reg_num = 0xFFFF # not a global but not a local?
+    check_registration() # in ATR2FUNC
     print()
-    # textcolor(3) #graphical
-    print(progname, ' ', version, ' ')
+    #textcolor(3) # graphical
+    print(progname, '', version, '')
     print(cnotice1)
     print(cnotice2)
-    #textcolor(7) #graphical 
+    #textcolor(7) # graphical 
     if not registered:
-        #textcolor(4) #graphical
+        #textcolor(4) # graphical
         print("Unregistered version")
     else:
         print("Registered to: ", reg_name)
-    #textcolor(7) #graphical 
+    #textcolor(7) # graphical 
     print()
     # {create_robot(0,'SDUCK');}
-    delete_compile_report() #from line 1353 - ported
-    if paramcount > 0:
-        parse_param(btrim(ucase(paramstr(i))))#line 1379##, btrim, ucase, paramstr?
+    delete_compile_report() # from line 1353 - ported
+    if paramcount > 0: # where is paramcount declared? 
+        parse_param(btrim(ucase(paramstr(i)))) # uses ATR2FUNC
     else:
-        prog_error(5, '')#ported
-    temp_mode = step_mode #{store initial step_mode}
+        prog_error(5, '') # ported
+    temp_mode = step_mode # {store initial step_mode}
     if logging_errors:
         for i in range (0, num_robots + 1):
-            robot[i].errorlog = open(base_name(fn) + '.ERR', 'w')
+            robot[i].errorlog = open(base_name(robot[i].fn) + '.ERR', 'w') # where is base_name defined? 
             if os.path.isfile(robot[i].errorlog):
                 os.remove(robot[i].errorlog)
-            robot[i].errorlog = open(base_name(fn) + '.ERR', 'w')
+            robot[i].errorlog = open(base_name(robot[i].fn) + '.ERR', 'w') # where is base_name defined, again?
             robot[i].errorlog.close()
     if compile_only:
-        write_compile_report() # line 1359 started but need help
+        write_compile_report() # line 1359 ported
     if num_robots < 1:
         prog_error(4, '')
     '''if not no_gfx: #commeting out since graphics-related
-        graph_mode(True) # ??? func on bool line 552'''
-    #{--fix ups--}
+        graph_mode(True) # func on bool line 552 '''
+    # {--fix ups--}
     if matches > 100000: matches = 100000
     if matches < 1: matches = 1
     if game_delay > 1000: game_delay = 1000
@@ -499,14 +609,14 @@ def init():#originally line 1452
     if time_slice < 1: time_slice = 1
     if game_limit < 0: game_limit = 0
     if game_limit > 100000: game_limit = 100000
-    if maxcode < 1: maxcode = 1# {0 based, so actually 2 lines}
+    if maxcode < 1: maxcode = 1 # {0 based, so actually 2 lines}
     if maxcode > max_code: maxcode = max_code
-    #{--Just to avoid floating pointers--}
+    # {--Just to avoid floating pointers--}
     for i in range(num_robots + 1, max_robots + 3):
         robot[i] = robot[0]
         robot[-1] = robot[0]
         robot[-2] = robot[0]
     if not graphix:
-        print("Freemem: ", memavail)
+        print("Freemem: ", memavail) # where is memavail defined? 
         print()
-#end init()
+# end init


### PR DESCRIPTION
Python is able to read global variables from within a function but not assign anything to them (change them) within the function unless they are declared global in the function - this version has the global access set up where needed.

Current issues that need to be resolved:

One function attempts to assign something to a variable declared in another function in the original code. This must be implemented somehow in Python. 

Some variables are not local and also don't appear to be global - Where are they declared?

create_robot() needs to be ported because parse_param(s) calls it.